### PR TITLE
fix steve commands for osx

### DIFF
--- a/src/os-specific/trolol-mac.js
+++ b/src/os-specific/trolol-mac.js
@@ -26,6 +26,10 @@ module.exports = {
 
     eject: function (times, wait) {
         exec(generateBashCommand('eject') + ' ' + times + ' ' + wait);
+    },
+
+    steve: function (wait) {
+        exec(generateBashCommand('steve') + ' ' + wait);
     }
 };
 


### PR DESCRIPTION
Got error when tried steve command and found that both steve & friday was missing for osx.

example error

```
› trolol steve --wait 10
/usr/local/lib/node_modules/trolol/src/trolol.js:27
        isMac() ? macTrolls.steve(wait) : linuxTrolls.steve(wait);
                            ^

TypeError: macTrolls.steve is not a function
    at Command.module.exports.steve (/usr/local/lib/node_modules/trolol/src/trolol.js:27:29)
```
