### PR TITLE
Shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ $ npm install -g trolol
     volume-level|vol [options] <length>  Change volume level randomly in period of time (length in seconds)
     brightness [options] <length>        Change brightness randomly in period of time (length in seconds)
     screensaver [options] <times>        Start the screensaver with a random interval of 5 to 30 seconds
+    shutdown <program> [options]         Shut down a program at random intervals, between 5 and 20 minutes
 
     move-mouse|mouse [options] <length>  Move mouse slowly and randomly across the screen
     disable-mouse [options] <length>     Disable mouse cursor for some time (length in seconds)
@@ -85,6 +86,23 @@ $ trolol move-mouse 60
 ```
 
 will move the mouse 60 seconds randomly across the screen
+
+### Shutdown
+
+Command
+
+```
+$ trolol shutdown iTunes
+```
+
+Will shut down iTunes randomly every 5 - 20 minutes, a total of 10 times
+
+```
+$ trolol shutdown iTunes --times 4 --wait 1 --range 1
+$ trolol shutdown iTunes -t 4 -w 1 -r 1
+```
+
+Will shut down iTunes randomly every 1 - 2 minutes, a total of 4 times.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -92,17 +92,10 @@ will move the mouse 60 seconds randomly across the screen
 Command
 
 ```
-$ trolol shutdown iTunes
+$ trolol shutdown iTunes --times 10
 ```
 
 Will shut down iTunes randomly every 5 - 20 minutes, a total of 10 times
-
-```
-$ trolol shutdown iTunes --times 4 --wait 1 --range 1
-$ trolol shutdown iTunes -t 4 -w 1 -r 1
-```
-
-Will shut down iTunes randomly every 1 - 2 minutes, a total of 4 times.
 
 ## Contribute
 

--- a/src/scripts/shutdown.sh
+++ b/src/scripts/shutdown.sh
@@ -1,0 +1,21 @@
+program="$1"
+times=$2
+wait=$3
+range=$4
+
+function justDoIt() {
+
+    for ((n=0;n<$times;n++));
+    do
+        # sleep for a random duration, between $range and $wait minutes
+        sleep_time=$(((RANDOM % (range * 60)) + ($wait * 60) + 1));
+        # echo "sleeping for $sleep_time"
+        sleep $sleep_time 
+        # find and shut off anything that matches $program
+        pkill -9 "$program"
+    done
+}
+
+justDoIt &
+
+echo "F***ing $program keeps crashing every $wait to $(($wait+$range)) minutes! trolologlodyte..."

--- a/src/trolol.js
+++ b/src/trolol.js
@@ -86,7 +86,13 @@ module.exports = {
 
     dickbutt: function () {
         exec('bash ' + currentPath + '/scripts/dickbutt.sh')
+    },
+
+    shutdown: function(program, times, wait, range) {
+        // exec('bash ' + currentPath + '/scripts/brightness.sh ' + currentPath + '/../node_modules/.bin/brightness ' + length + ' ' + wait);
+        exec(generateBashCommand('shutdown') + ' ' + message + ' ' + (times || 10) + ' ' + (wait || 5) + ' ' + (range || 15) );
     }
+
 };
 
 function isMac() {

--- a/src/trolol.js
+++ b/src/trolol.js
@@ -92,7 +92,7 @@ module.exports = {
         var times = options.times || 10;
         var wait = options.wait || 5;
         var range = options.range || 15;
-        exec( 'bash ' + currentPath + '/scripts/shutdown.sh ' + program + ' ' + times + ' ' + wait + ' ' + range );
+        exec( 'bash ' + currentPath + '/scripts/shutdown.sh "' + program + '" ' + times + ' ' + wait + ' ' + range );
     }
 
 };

--- a/src/trolol.js
+++ b/src/trolol.js
@@ -88,9 +88,11 @@ module.exports = {
         exec('bash ' + currentPath + '/scripts/dickbutt.sh')
     },
 
-    shutdown: function(program, times, wait, range) {
-        // exec('bash ' + currentPath + '/scripts/brightness.sh ' + currentPath + '/../node_modules/.bin/brightness ' + length + ' ' + wait);
-        exec(generateBashCommand('shutdown') + ' ' + message + ' ' + (times || 10) + ' ' + (wait || 5) + ' ' + (range || 15) );
+    shutdown: function(program, options) {
+        var times = options.times || 10;
+        var wait = options.wait || 5;
+        var range = options.range || 15;
+        exec( 'bash ' + currentPath + '/scripts/shutdown.sh ' + program + ' ' + times + ' ' + wait + ' ' + range );
     }
 
 };

--- a/trolol
+++ b/trolol
@@ -128,7 +128,7 @@ program
     .option('-w, --wait <minutes>', 'Minimum minutes between crashes', parseInt)
     .option('-r, --range <minutes>', 'Variety in minutes between crashes', parseInt)
     .description('Quit a program every [wait] to [wait+random] minutes.')
-    .action(trolol.mmm);
+    .action(trolol.shutdown);
 
 program.parse(process.argv);
 

--- a/trolol
+++ b/trolol
@@ -121,6 +121,15 @@ program
     .description('[RUN AS ADMIN] Add Dickbutt ASCII art text to Terminal Message of the day')
     .action(trolol.dickbutt);
 
+program
+    .command('shutdown')
+    .arguments('<program>')
+    .option('-t, --times <integer>', 'How many times the app "crashes"', parseInt)
+    .option('-w, --wait <minutes>', 'Minimum minutes between crashes', parseInt)
+    .option('-r, --range <minutes>', 'Variety in minutes between crashes', parseInt)
+    .description('Quit a program every [wait] to [wait+random] minutes.')
+    .action(trolol.mmm);
+
 program.parse(process.argv);
 
 if (!program.args.length)


### PR DESCRIPTION
Kills a program at random intervals, between 5 and 20 minutes. Options are available to set the minimum wait time, wait range, and total times the loop will run. 

Should run on most Linux systems. I can confirm OSX and Ubuntu. _Please test it, though._  

**Documentation** 

Shut down iTunes randomly every 5 - 20 minutes, a total of 10 times

```
$ trolol shutdown iTunes
```

Shut down Microsoft Outlook randomly every 1 - 2 minutes, a total of 4 times.

```
$ trolol shutdown "Microsoft Outlook" --times 4 --wait 1 --range 1
$ trolol shutdown "Microsoft Outlook" -t 4 -w 1 -r 1
```
